### PR TITLE
Use arch on Darwin systems

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -24,10 +24,11 @@ LZ4_OBJS := $(LZ4_SRC)/lib/*.o
 
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
+	SYS_ARCH := $(shell arch)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -arch $(SYS_ARCH) -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch $(SYS_ARCH) -finline-functions -Wall
+	LDFLAGS ?= -arch $(SYS_ARCH) -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -24,7 +24,7 @@ LZ4_OBJS := $(LZ4_SRC)/lib/*.o
 
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
-	SYS_ARCH := $(shell arch)
+	SYS_ARCH := $(shell uname -m)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -arch $(SYS_ARCH) -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -arch $(SYS_ARCH) -finline-functions -Wall


### PR DESCRIPTION
With the release of M1 Macs, we need to check the arch (x86_64 OR arm64) or the compilation step of lz4b will fail and the module won't be loadable.

This changes the makefile to check `arch` on Darwin systems.

Resolve #7 