### PR TITLE
Upgrade to lz4 1.10 and fix 4096 byte compression

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -15,7 +15,7 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT)_nif.so
 
 
 LZ4 ?= lz4
-LZ4_VSN ?= 1.9.2
+LZ4_VSN ?= 1.10.0
 LZ4_SRC ?= $(LZ4)-$(LZ4_VSN)
 LZ4_SRC_TAR ?= v$(LZ4_VSN).tar.gz
 LZ4_SRC_PACKAGE_LINK ?= https://github.com/lz4/lz4/archive/$(LZ4_SRC_TAR)

--- a/c_src/lz4b.c
+++ b/c_src/lz4b.c
@@ -29,12 +29,7 @@ static ERL_NIF_TERM frame_compress(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     return ERROR_ATOM("bad_preference");
   }
 
-  if (bin.size < 4096)
-    {
-      cap = 4096;
-    } else {
-    cap = LZ4F_compressFrameBound((size_t) bin.size, pref);
-  }
+  cap = LZ4F_compressFrameBound((size_t) bin.size, pref);
 
   if (!enif_alloc_binary(cap, &output)) {
     free(pref);
@@ -359,9 +354,9 @@ int parse_edecompressOption(ErlNifEnv* env,
   enif_get_uint(env, *(opts+1), (unsigned int *) stepsize);
   enif_get_uint(env, *(opts+2), (unsigned int *) buffgrow_size);
   enif_get_uint(env, *(opts+3), &(dccopt -> stableDst));
-  enif_get_uint(env, *(opts+4), &(dccopt -> reserved[0]));
-  enif_get_uint(env, *(opts+5), &(dccopt -> reserved[1]));
-  enif_get_uint(env, *(opts+6), &(dccopt -> reserved[2]));
+  enif_get_uint(env, *(opts+4), &(dccopt -> skipChecksums));
+  enif_get_uint(env, *(opts+5), &(dccopt -> reserved1));
+  enif_get_uint(env, *(opts+6), &(dccopt -> reserved0));
   return 1;
 }
 


### PR DESCRIPTION
## Changes
 - Update to lz4 to 1.10
 - Fix bug where compression would fail for batch sizes just under 4096 bytes.

### Bug Description

 - From the [compress_frame](https://github.com/lz4/lz4/blob/dev/lib/lz4frame.h#L219) function `@dstCapacity MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr)`.
However for message close to 4096 bytes, it looks like it is possible for slight expansion. Running a quick test with the message batch just under 4096:
   - The raw data size is 4086 (so under the 4096) threshold so allocates 4096 buffer size.
    - Running the same batch through LZ4F_compressFrameBound returns a result of 4113
    - This means @dstCapacity MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr) is not met and 💣 💥 with a ERROR_dstMaxSize_tooSmall error